### PR TITLE
ci: PR作成者を自動でアサインするワークフローを追加

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened]
 
 permissions:
-  pull-requests: write
+  issues: write
 
 jobs:
   assign:
@@ -15,9 +15,13 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              assignees: [context.payload.pull_request.user.login],
-            });
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                assignees: [context.payload.pull_request.user.login],
+              });
+            } catch (error) {
+              core.warning(`PR作成者のアサインに失敗しました: ${error.message}`);
+            }

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -1,0 +1,23 @@
+name: Auto Assign Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login],
+            });


### PR DESCRIPTION
## 概要

PRが開かれた（または再オープンされた）際に、作成者を自動でassigneeに設定するGitHub Actionsワークフローを追加します。

## 変更内容

- \`.github/workflows/auto-assign-author.yaml\` を新規追加
  - \`pull_request_target\` の \`opened\` / \`reopened\` をトリガーに、\`actions/github-script\` でPR作成者をアサインする

## 既存の書き方への準拠

- アクションはコミットSHA + バージョンコメントでピン留め（\`actions/github-script@3a2844b...\` # v9.0.0）
- ファイル拡張子は多数派の \`.yaml\` に統一
- stepに \`name\` を付与

🤖 Generated with [Claude Code](https://claude.com/claude-code)