### PR TITLE
fix: コピーボタンの文言を「コピーする」「コピー済み」に変更

### DIFF
--- a/app/ginga-ui.com/src/components/code-block.tsx
+++ b/app/ginga-ui.com/src/components/code-block.tsx
@@ -11,8 +11,8 @@ export function CodeBlock({ code, highlightedCode, filename }: CodeBlockProps) {
     <CoreCodeBlock
       code={code}
       filename={filename}
-      copyLabel="コピー"
-      copiedLabel="コピー完了!"
+      copyLabel="コピーする"
+      copiedLabel="コピー済み"
     >
       {highlightedCode ? (
         <div dangerouslySetInnerHTML={{ __html: highlightedCode }} />


### PR DESCRIPTION
## 概要

ドキュメントサイトのCodeBlockのコピーボタン文言を「コピー」/「コピー完了!」から「コピーする」/「コピー済み」に変更します。

## 依存

#91 をベースにしたPRです。#91 のマージ後にベースがmainに切り替わります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)