### PR TITLE
fix: CardのスタイルをCodeBlockと統一

### DIFF
--- a/.changeset/plenty-moons-shake.md
+++ b/.changeset/plenty-moons-shake.md
@@ -5,5 +5,5 @@
 CodeBlock コンポーネントを追加し、Card と Anchor のスタイルを見直し
 
 - CodeBlock コンポーネントを新規追加。クリップボードコピー機能を内蔵し、シンタックスハイライト済みの React 要素を children で注入可能(shiki 等は非内包)
-- Card の視覚変更: border を `--color-primary-9` に変更し、box-shadow を削除
+- Card の視覚変更: CodeBlock と同じ外観に統一(border を `--color-primary-2` に、padding 1rem を Card 本体に移動し各セクションの間隔は gap で管理)し、box-shadow を削除
 - Anchor `variant="button"` の視覚変更: Button と統一(角丸を `calc(var(--size-radius) * 0.5)` に、フォーカスリングを outline 方式に、disabled 表現と transition を Button と同一に)

--- a/packages/core/src/components/card/index.css
+++ b/packages/core/src/components/card/index.css
@@ -1,8 +1,12 @@
 .ginga-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
   font-family: var(--font-family);
   color: var(--color-secondary-9);
   background-color: var(--color-background);
-  border: 1px solid var(--color-primary-9);
+  border: 1px solid var(--color-primary-2);
   border-radius: calc(var(--size-radius) * 0.5);
 }
 
@@ -10,7 +14,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 1rem;
 }
 
 .ginga-card-title {
@@ -24,15 +27,8 @@
   font-size: 1rem;
 }
 
-.ginga-card-content {
-  padding: 1rem;
-  padding-top: 0;
-}
-
 .ginga-card-footer {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-  padding: 1rem;
-  padding-top: 0;
 }


### PR DESCRIPTION
## 概要

CardをCodeBlockと同じ外観に統一します。

- border色を`--color-primary-2`に変更
- padding 1remをCard本体(`.ginga-card`)に移動し、CardHeader/CardContent/CardFooter間の間隔はflexのgapで管理(二重paddingを回避)
- 角丸は元からCodeBlockと同一(`calc(var(--size-radius) * 0.5)`)のため変更なし

これにより`<Card>`直下に要素を置いた場合(ドキュメントサイトのトップページ等)でも適切な余白が付きます。changesetのCardの記述も最終状態に合わせて更新しました。

## 依存

#91 をベースにしたPRです。#91 のマージ後にベースがmainに切り替わります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)