### PR TITLE
feat: ドキュメントサイトのヘッダーを固定表示に変更

### DIFF
--- a/app/ginga-ui.com/src/app/globals.css
+++ b/app/ginga-ui.com/src/app/globals.css
@@ -19,6 +19,9 @@ body {
 }
 
 .docs-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
## 概要

ginga-ui.comのヘッダー(`.docs-header`)を`position: sticky`でスクロール時も画面上部に固定表示するようにします。コンテンツより手前に表示されるよう`z-index: 100`を設定しています。

## 依存

#91 をベースにしたPRです(変更自体は独立していますが、コンフリクト回避のため同一ベースに揃えています)。#91 のマージ後にベースがmainに切り替わります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)