### PR TITLE
fix: スタックPR3件(#92〜#94)をmainに取り込み

### DIFF
--- a/.changeset/plenty-moons-shake.md
+++ b/.changeset/plenty-moons-shake.md
@@ -5,5 +5,5 @@
 CodeBlock コンポーネントを追加し、Card と Anchor のスタイルを見直し
 
 - CodeBlock コンポーネントを新規追加。クリップボードコピー機能を内蔵し、シンタックスハイライト済みの React 要素を children で注入可能(shiki 等は非内包)
-- Card の視覚変更: border を `--color-primary-9` に変更し、box-shadow を削除
+- Card の視覚変更: CodeBlock と同じ外観に統一(border を `--color-primary-2` に、padding 1rem を Card 本体に移動し各セクションの間隔は gap で管理)し、box-shadow を削除
 - Anchor `variant="button"` の視覚変更: Button と統一(角丸を `calc(var(--size-radius) * 0.5)` に、フォーカスリングを outline 方式に、disabled 表現と transition を Button と同一に)

--- a/app/ginga-ui.com/src/app/globals.css
+++ b/app/ginga-ui.com/src/app/globals.css
@@ -19,6 +19,9 @@ body {
 }
 
 .docs-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/app/ginga-ui.com/src/components/code-block.tsx
+++ b/app/ginga-ui.com/src/components/code-block.tsx
@@ -11,8 +11,8 @@ export function CodeBlock({ code, highlightedCode, filename }: CodeBlockProps) {
     <CoreCodeBlock
       code={code}
       filename={filename}
-      copyLabel="コピー"
-      copiedLabel="コピー完了!"
+      copyLabel="コピーする"
+      copiedLabel="コピー済み"
     >
       {highlightedCode ? (
         <div dangerouslySetInnerHTML={{ __html: highlightedCode }} />

--- a/packages/core/src/components/card/index.css
+++ b/packages/core/src/components/card/index.css
@@ -1,8 +1,12 @@
 .ginga-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
   font-family: var(--font-family);
   color: var(--color-secondary-9);
   background-color: var(--color-background);
-  border: 1px solid var(--color-primary-9);
+  border: 1px solid var(--color-primary-2);
   border-radius: calc(var(--size-radius) * 0.5);
 }
 
@@ -10,7 +14,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 1rem;
 }
 
 .ginga-card-title {
@@ -24,15 +27,8 @@
   font-size: 1rem;
 }
 
-.ginga-card-content {
-  padding: 1rem;
-  padding-top: 0;
-}
-
 .ginga-card-footer {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-  padding: 1rem;
-  padding-top: 0;
 }


### PR DESCRIPTION
## 概要

#92〜#94 はベースが `feat/code-block-card-anchor` のままマージされたため、mainに取り込まれていませんでした。このPRでその3件をmainに反映します。

- #92 コピーボタンの文言を「コピーする」「コピー済み」に変更
- #93 CardのスタイルをCodeBlockと統一
- #94 ドキュメントサイトのヘッダーを固定表示に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)