### PR TITLE
feat: stylelint で font-weight と rem の値を制限する

### DIFF
--- a/.changeset/plenty-moons-shake.md
+++ b/.changeset/plenty-moons-shake.md
@@ -17,3 +17,5 @@ AlertDialog / Drawer / Popover / Alert / Badge / Toast コンポーネントを�
 - Drawer: placement で4方向(left / right / top / bottom)のスライドインに対応。dismissable prop で外側クリック時の挙動を制御
 - Popover: react-aria の Popover をラップし、非モーダル Dialog と矢印(OverlayArrow)を内蔵。placement / showArrow でカスタマイズ可能
 - Toast: react-aria の UNSTABLE\_ Toast API をラップ。`toast.show` / `info` / `success` / `warning` / `danger` / `close` の関数 API と、4隅に配置可能な ToastRegion を提供
+
+stylelint で `font-weight` を 400 / 700、長さの rem を 0.125rem 刻みに制限し、違反箇所を修正

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,15 @@
 {
   "extends": ["stylelint-config-standard", "stylelint-config-recess-order"],
+  "ignoreFiles": ["**/dist/**", "**/.next/**", "**/storybook-static/**"],
   "rules": {
     "selector-class-pattern": null,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "font-weight-notation": "numeric",
+    "declaration-property-value-allowed-list": {
+      "font-weight": ["400", "700"]
+    },
+    "declaration-property-value-disallowed-list": {
+      "/.+/": ["/(?<![\\d.])\\d*\\.(?!(?:125|25|375|5|625|75|875)rem)\\d+rem/"]
+    }
   }
 }

--- a/app/ginga-ui.com/src/app/globals.css
+++ b/app/ginga-ui.com/src/app/globals.css
@@ -96,7 +96,7 @@ body {
 .sidebar a {
   display: block;
   padding: 0.5rem 0.75rem;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   color: var(--color-secondary);
   text-decoration: none;
   border-radius: calc(var(--size-radius) / 2);
@@ -179,7 +179,7 @@ body {
 
 .component-card p {
   margin: 0 0 1rem;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.6;
   color: var(--color-secondary);
 }

--- a/app/ginga-ui.com/src/app/globals.css
+++ b/app/ginga-ui.com/src/app/globals.css
@@ -46,7 +46,7 @@ body {
 }
 
 .header-nav a {
-  font-weight: 500;
+  font-weight: 400;
   color: var(--color-secondary);
   text-decoration: none;
   transition: color 0.2s;
@@ -77,7 +77,7 @@ body {
 .sidebar h2 {
   margin: 0 0 0.75rem;
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -109,7 +109,7 @@ body {
 }
 
 .sidebar a[data-active="true"] {
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-background);
   background-color: var(--color-primary);
 }
@@ -187,7 +187,7 @@ body {
 .view-details {
   display: inline-block;
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-primary);
 }
 

--- a/app/ginga-ui.com/src/components/theme-generator.module.css
+++ b/app/ginga-ui.com/src/components/theme-generator.module.css
@@ -14,15 +14,15 @@
 
 .warningText {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   line-height: 1.6;
 }
 
 .fieldLabel {
   display: block;
   margin-bottom: 0.5rem;
-  font-size: 0.9375rem;
-  font-weight: 600;
+  font-size: 0.875rem;
+  font-weight: 700;
 }
 
 .errorBox {

--- a/packages/core/src/components/accordion/index.css
+++ b/packages/core/src/components/accordion/index.css
@@ -16,7 +16,7 @@
   padding: 1rem;
   font-family: var(--font-family);
   font-size: 1rem;
-  font-weight: 800;
+  font-weight: 700;
   color: var(--color-primary-9);
   text-align: left;
   cursor: pointer;

--- a/packages/core/src/components/alert-dialog/index.css
+++ b/packages/core/src/components/alert-dialog/index.css
@@ -49,5 +49,5 @@
   margin-bottom: 1rem;
   font-family: var(--font-family);
   font-size: 1.25rem;
-  font-weight: 800;
+  font-weight: 700;
 }

--- a/packages/core/src/components/alert-dialog/index.css
+++ b/packages/core/src/components/alert-dialog/index.css
@@ -9,8 +9,8 @@
   border-top: 0.25rem solid var(--color-secondary-9);
   border-radius: calc(var(--size-radius) * 0.5);
   box-shadow:
-    0 0.25rem 0.375rem -0.0625rem rgb(0 0 0 / 10%),
-    0 0.125rem 0.25rem -0.0625rem rgb(0 0 0 / 6%);
+    0 0.25rem 0.375rem -0.125rem rgb(0 0 0 / 10%),
+    0 0.125rem 0.25rem -0.125rem rgb(0 0 0 / 6%);
 
   &[data-variant="info"] {
     border-top-color: var(--color-info);

--- a/packages/core/src/components/anchor/index.css
+++ b/packages/core/src/components/anchor/index.css
@@ -21,10 +21,10 @@
 
   &[data-focus-visible]::after {
     position: absolute;
-    inset: -0.3rem;
+    inset: -0.25rem;
     content: "";
     border: var(--width-border) solid var(--color-primary-5);
-    border-radius: calc(var(--size-radius) * 0.3);
+    border-radius: calc(var(--size-radius) * 0.25);
   }
 
   &[data-variant="button"] {

--- a/packages/core/src/components/badge/index.css
+++ b/packages/core/src/components/badge/index.css
@@ -5,7 +5,7 @@
   padding: 0.125rem 0.5rem;
   font-family: var(--font-family);
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1.25rem;
   white-space: nowrap;
   border-radius: calc(var(--size-radius) * 0.5);

--- a/packages/core/src/components/card/index.css
+++ b/packages/core/src/components/card/index.css
@@ -18,7 +18,7 @@
 
 .ginga-card-title {
   font-size: 1.5rem;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 .ginga-card-description {

--- a/packages/core/src/components/checkbox/index.css
+++ b/packages/core/src/components/checkbox/index.css
@@ -11,8 +11,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 1.25rem;
+    height: 1.25rem;
     cursor: pointer;
     border: var(--width-border) solid var(--color-primary-9);
     border-radius: calc(var(--size-radius) * 0.5);

--- a/packages/core/src/components/code-block/index.css
+++ b/packages/core/src/components/code-block/index.css
@@ -18,7 +18,7 @@
 
 .ginga-code-block-filename {
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 400;
   color: var(--color-secondary);
 }
 

--- a/packages/core/src/components/dialog/index.css
+++ b/packages/core/src/components/dialog/index.css
@@ -33,5 +33,5 @@
   margin-bottom: 1rem;
   font-family: var(--font-family);
   font-size: 1.5rem;
-  font-weight: 800;
+  font-weight: 700;
 }

--- a/packages/core/src/components/drawer/index.css
+++ b/packages/core/src/components/drawer/index.css
@@ -102,7 +102,7 @@
   margin-bottom: 1rem;
   font-family: var(--font-family);
   font-size: 1.5rem;
-  font-weight: 800;
+  font-weight: 700;
 }
 
 @keyframes ginga-drawer-fade {

--- a/packages/core/src/components/drawer/index.css
+++ b/packages/core/src/components/drawer/index.css
@@ -20,8 +20,8 @@
     display: flex;
     background-color: var(--color-background);
     box-shadow:
-      0 0.25rem 0.375rem -0.0625rem rgb(0 0 0 / 10%),
-      0 0.125rem 0.25rem -0.0625rem rgb(0 0 0 / 6%);
+      0 0.25rem 0.375rem -0.125rem rgb(0 0 0 / 10%),
+      0 0.125rem 0.25rem -0.125rem rgb(0 0 0 / 6%);
   }
 
   &[data-placement="left"] .ginga-drawer {

--- a/packages/core/src/components/form-control/index.css
+++ b/packages/core/src/components/form-control/index.css
@@ -7,7 +7,7 @@
 .ginga-form-control-label {
   margin-bottom: 0.5rem;
   font-family: var(--font-family);
-  font-weight: bold;
+  font-weight: 700;
   color: var(--color-primary);
 }
 

--- a/packages/core/src/components/heading/index.css
+++ b/packages/core/src/components/heading/index.css
@@ -12,7 +12,7 @@
 }
 
 .ginga-heading-level-3 {
-  font-size: 10.25rem;
+  font-size: 1.25rem;
 }
 
 .ginga-heading-level-4 {

--- a/packages/core/src/components/popover/index.css
+++ b/packages/core/src/components/popover/index.css
@@ -5,8 +5,8 @@
   border: var(--width-border) solid var(--color-secondary-9);
   border-radius: calc(var(--size-radius) * 0.5);
   box-shadow:
-    0 0.25rem 0.375rem -0.0625rem rgb(0 0 0 / 10%),
-    0 0.125rem 0.25rem -0.0625rem rgb(0 0 0 / 6%);
+    0 0.25rem 0.375rem -0.125rem rgb(0 0 0 / 10%),
+    0 0.125rem 0.25rem -0.125rem rgb(0 0 0 / 6%);
 
   &[data-entering] {
     animation: ginga-popover-enter 150ms ease-out;

--- a/packages/core/src/components/radio/index.css
+++ b/packages/core/src/components/radio/index.css
@@ -9,12 +9,12 @@
   &::before {
     box-sizing: border-box;
     display: block;
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 1.25rem;
+    height: 1.25rem;
     cursor: pointer;
     content: "";
     background: var(--color-background);
-    border: 0.143rem solid var(--color-primary-9);
+    border: 0.125rem solid var(--color-primary-9);
     border-radius: 50%;
     transition: all 0.2s;
   }

--- a/packages/core/src/components/select/index.css
+++ b/packages/core/src/components/select/index.css
@@ -21,7 +21,7 @@
   margin-bottom: 0.5rem;
   font-family: var(--font-family);
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 400;
   color: var(--color-secondary-9);
 }
 
@@ -103,7 +103,6 @@
   }
 
   &[data-selected] {
-    font-weight: 500;
     color: var(--color-background);
     background-color: var(--color-primary-9);
   }

--- a/packages/core/src/components/switch/index.css
+++ b/packages/core/src/components/switch/index.css
@@ -17,12 +17,12 @@
 
     &::before {
       display: block;
-      width: 0.9rem;
-      height: 0.9rem;
-      margin: 0.05rem 0.1rem;
+      width: 0.75rem;
+      height: 0.75rem;
+      margin: 0.125rem;
       content: "";
       background: var(--color-primary-9);
-      border-radius: calc(var(--size-radius) * 0.5 - 0.1rem);
+      border-radius: calc(var(--size-radius) * 0.5);
       transition: all 0.2s;
     }
   }
@@ -42,7 +42,7 @@
 
       &::before {
         background: var(--color-background);
-        transform: translateX(100%);
+        transform: translateX(1rem);
       }
     }
 

--- a/packages/core/src/components/table/index.css
+++ b/packages/core/src/components/table/index.css
@@ -14,7 +14,7 @@
 
 .ginga-column {
   padding: 0.75rem;
-  font-weight: 600;
+  font-weight: 700;
   text-align: left;
   border-bottom: 2px solid var(--color-secondary-2);
 }

--- a/packages/core/src/components/toast/index.css
+++ b/packages/core/src/components/toast/index.css
@@ -44,8 +44,8 @@
   border-left: 0.25rem solid;
   border-radius: calc(var(--size-radius) * 0.5);
   box-shadow:
-    0 0.25rem 0.375rem -0.0625rem rgb(0 0 0 / 10%),
-    0 0.125rem 0.25rem -0.0625rem rgb(0 0 0 / 6%);
+    0 0.25rem 0.375rem -0.125rem rgb(0 0 0 / 10%),
+    0 0.125rem 0.25rem -0.125rem rgb(0 0 0 / 6%);
   animation: ginga-toast-enter 200ms ease-out;
 
   &[data-variant="info"] {
@@ -91,7 +91,7 @@
 }
 
 .ginga-toast-description {
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
 }
 
 .ginga-toast-close {
@@ -110,7 +110,7 @@
 
   &[data-focus-visible] {
     outline: 0.125rem solid var(--color-primary-5);
-    outline-offset: 0.0625rem;
+    outline-offset: 0.125rem;
   }
 }
 


### PR DESCRIPTION
Closes #88
Closes #89

## 変更内容

### ルール追加 (`.stylelintrc`)

stylelint 17 の組み込みルールのみで実現しており、新規パッケージの追加はありません。

- `declaration-property-value-allowed-list`: `font-weight` を `400` / `700` に限定 (#88)
- `declaration-property-value-disallowed-list`: 小数点以下が 125 / 25 / 375 / 5 / 625 / 75 / 875 でない rem 値を禁止 (#89)
- `ignoreFiles`: 従来 `pnpm stylelint` がビルド成果物 `packages/core/dist` まで lint し `--fix` で書き換えていたため除外

### 違反箇所の修正 (計 37 件)

- font-weight 14 箇所: 800 / 600 / bold → 700、500 → 400
- rem 23 箇所: box-shadow の spread `-0.0625rem` → `-0.125rem`、Radio / Checkbox `1.2rem` → `1.25rem`、Radio の border `0.143rem` → `0.125rem`、Toast の説明文 `0.8125rem` → `0.75rem` など
- Switch はつまみを `0.75rem` 角 + `margin: 0.125rem` に組み直し、`translateX(100%)` → `translateX(1rem)`
- あわせて Heading `level-3` の `font-size` が `10.25rem` になっていた不具合を修正

## 確認事項

- [x] `npx tsc --noEmit && pnpm run lint && pnpm run format && pnpm run stylelint` が通過
- [ ] Storybook で Switch / Radio / Checkbox / Toast / Heading の見た目を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)