### PR TITLE
feat: ThemeClient に Gemini Nano を使う provider を追加

### DIFF
--- a/.changeset/plenty-moons-shake.md
+++ b/.changeset/plenty-moons-shake.md
@@ -29,3 +29,5 @@ ThemeClient のプロバイダー指定方法を変更し、デフォルトモ�
 - `ThemeProvider` 型と `DEFAULT_MODELS` / `PROVIDERS` を新たにエクスポート
 - ドキュメントサイト・README・Storybook のモデル例リストを最新世代に更新
 - AI SDK を同世代の最新版に更新。`ai` 7.0.58 / `@ai-sdk/openai` 4.0.36 / `@ai-sdk/google` 4.0.39 / `@ai-sdk/anthropic` 4.0.36
+
+ThemeClient に Gemini Nano を使う `provider: "browser"` を追加

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm run:*)",
+      "Bash(grep:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh issue *)",
+      "Bash(gh pr *)"
+    ],
+    "deny": [
+      "Bash(git reset:*)",
+      "Bash(git rebase:*)",
+      "Read(.env)",
+      "Read(*.env)",
+      "Read(.env.local)",
+      "Bash(cat *.env)",
+      "Bash(cat *.env.local)",
+      "Bash(head *.env)",
+      "Bash(head *.env.local)",
+      "Bash(tail *.env)",
+      "Bash(tail *.env.local)",
+      "Bash(less *.env)",
+      "Bash(less *.env.local)",
+      "Bash(more *.env)",
+      "Bash(more *.env.local)",
+      "Bash(grep *.env)",
+      "Bash(grep *.env.local)",
+      "Bash(sed *.env)",
+      "Bash(sed *.env.local)",
+      "Bash(awk *.env)",
+      "Bash(awk *.env.local)",
+      "Bash(vim *.env)",
+      "Bash(vim *.env.local)",
+      "Bash(nano *.env)",
+      "Bash(nano *.env.local)",
+      "Bash(bat *.env)",
+      "Bash(bat *.env.local)"
+    ],
+    "ask": [
+      "Bash(git checkout:*)",
+      "Bash(git merge:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(rm:*)"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledPlugins": {
+    "github@claude-plugins-official": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ TypeScriptパスマッピングを使用:
    - `provider: "openai"` — デフォルトモデルは `gpt-5.6-luna`
    - `provider: "google"` — デフォルトモデルは `gemini-3.7-flash`
    - `provider: "anthropic"` — デフォルトモデルは `claude-haiku-4-5`
+   - `provider: "browser"` — Gemini Nano。APIキー不要でブラウザ内でのみ動作するため、Client Component から呼ぶ。`@browser-ai/core` は動的 import して読み込む
 
 2. **テーマ生成フロー**:
    - LLMがプロンプトに基づいてCSS変数を生成
@@ -105,6 +106,7 @@ TypeScriptパスマッピングを使用:
    - 最大リトライ回数に達した場合は色を調整してコントラストを強制
    - プライマリ・セカンダリカラーの中間色スケール（0-9）を生成
    - `<style>`タグで適用可能なCSSコードを返す
+   - `getBrowserAIAvailability()` で Gemini Nano が使えるかを判定できる
 
 3. **CSS変数システム**:
    - コア変数: `--color-primary`、`--color-secondary`、`--color-background`、`--width-border`、`--size-radius`、`--font-family`
@@ -131,7 +133,7 @@ TypeScriptパスマッピングを使用:
 
 ### クライアントサイドの安全性
 
-APIキーはVercel AI SDKが環境変数から読み込みます。クライアントサイドにAPIキーを渡すと露出するため、テーマ生成はServer ComponentsやRoute Handlerなどのサーバーサイドで実行してください。
+APIキーはVercel AI SDKが環境変数から読み込みます。クライアントサイドにAPIキーを渡すと露出するため、テーマ生成はServer ComponentsやRoute Handlerなどのサーバーサイドで実行してください。ただし `provider: "browser"` はAPIキーを必要とせずブラウザ内でのみ動作するため、Client Componentから呼び出します。
 
 ### サーバーサイドレンダリング
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can generate with your own theme by using `ThemeClient` class powered by [Ve
 - Anthropic: `ANTHROPIC_API_KEY`
 - Google: `GOOGLE_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY`
 
-Set these environment variables in your `.env` file or deployment environment.
+Set these environment variables in your `.env` file or deployment environment. `provider: "browser"` needs no API key.
 
 ### Basic Usage
 
@@ -115,13 +115,40 @@ export default async function Home() {
 
 Specify the provider explicitly with `provider`. If `model` is omitted, the default model for that provider is used.
 
-| Provider  | `provider`    | Default model      | Other examples                            |
-| --------- | ------------- | ------------------ | ----------------------------------------- |
-| OpenAI    | `"openai"`    | `gpt-5.6-luna`     | `gpt-5.6-terra`, `gpt-5.6-sol`            |
-| Google    | `"google"`    | `gemini-3.7-flash` | `gemini-3.5-flash-lite`, `gemini-2.5-pro` |
-| Anthropic | `"anthropic"` | `claude-haiku-4-5` | `claude-sonnet-5`, `claude-opus-5`        |
+| Provider    | `provider`    | Default model      | Other examples                            |
+| ----------- | ------------- | ------------------ | ----------------------------------------- |
+| OpenAI      | `"openai"`    | `gpt-5.6-luna`     | `gpt-5.6-terra`, `gpt-5.6-sol`            |
+| Google      | `"google"`    | `gemini-3.7-flash` | `gemini-3.5-flash-lite`, `gemini-2.5-pro` |
+| Anthropic   | `"anthropic"` | `claude-haiku-4-5` | `claude-sonnet-5`, `claude-opus-5`        |
+| Gemini Nano | `"browser"`   | -                  | -                                         |
 
 You can use any model supported by the [Vercel AI SDK](https://sdk.vercel.ai/providers/ai-sdk-providers).
+
+### Gemini Nano
+
+`provider: "browser"` runs [Gemini Nano](https://developer.chrome.com/docs/ai/built-in), the model shipped with Chrome and Edge. It needs no API key and no network request, but it only works in the browser, so call it from a Client Component instead of a Server Component. `model` is ignored.
+
+```tsx
+"use client";
+
+import { getBrowserAIAvailability, ThemeClient } from "@ginga-ui/utils";
+
+const generate = async () => {
+  const availability = await getBrowserAIAvailability();
+
+  if (availability === "unavailable") {
+    return;
+  }
+
+  const themeClient = new ThemeClient({ provider: "browser" });
+
+  const { CSSCode } = await themeClient.generateTheme("deep sea", {
+    onDownloadProgress: (progress) => console.log(progress),
+  });
+};
+```
+
+`getBrowserAIAvailability()` returns `"unavailable"` / `"downloadable"` / `"downloading"` / `"available"`. Fall back to a cloud provider when it is `"unavailable"`. The first run downloads several gigabytes of model data, so report the progress with `onDownloadProgress`.
 
 #### Examples
 
@@ -144,10 +171,10 @@ const themeClient = new ThemeClient({
 
 ### `ThemeClient` Constructor Options
 
-| Name       | Description                                                   | Default Value                 | Required |
-| ---------- | ------------------------------------------------------------- | ----------------------------- | -------- |
-| `provider` | LLM provider to use. `"openai"` / `"google"` / `"anthropic"`. | -                             | Yes      |
-| `model`    | Model name to use for theme generation.                       | Default model of the provider | No       |
+| Name       | Description                                                                 | Default Value                 | Required |
+| ---------- | --------------------------------------------------------------------------- | ----------------------------- | -------- |
+| `provider` | LLM provider to use. `"openai"` / `"google"` / `"anthropic"` / `"browser"`. | -                             | Yes      |
+| `model`    | Model name to use for theme generation.                                     | Default model of the provider | No       |
 
 ## Variables
 

--- a/app/ginga-ui.com/src/app/api/generate-theme/route.ts
+++ b/app/ginga-ui.com/src/app/api/generate-theme/route.ts
@@ -1,7 +1,9 @@
 import { ThemeClient, type ThemeProvider } from "@ginga-ui/utils";
 import { NextRequest, NextResponse } from "next/server";
 
-const ENV_KEYS: Record<ThemeProvider, string> = {
+type ServerThemeProvider = Exclude<ThemeProvider, "browser">;
+
+const ENV_KEYS: Record<ServerThemeProvider, string> = {
   openai: "OPENAI_API_KEY",
   google: "GOOGLE_GENERATIVE_AI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
@@ -18,7 +20,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const envKey = ENV_KEYS[provider as ThemeProvider];
+    const envKey = ENV_KEYS[provider as ServerThemeProvider];
 
     if (!envKey) {
       return NextResponse.json(

--- a/app/ginga-ui.com/src/app/theme-generation/page.module.css
+++ b/app/ginga-ui.com/src/app/theme-generation/page.module.css
@@ -67,3 +67,7 @@
 .scaleNote {
   margin-top: 1.5rem;
 }
+
+.browserSection {
+  margin-top: 4rem;
+}

--- a/app/ginga-ui.com/src/app/theme-generation/page.tsx
+++ b/app/ginga-ui.com/src/app/theme-generation/page.tsx
@@ -16,7 +16,8 @@ export default async function ThemeGenerationPage() {
       <section className={styles.demoSection}>
         <Heading level="h2">ライブデモ</Heading>
         <Paragraph>
-          下のフォームでAPIキーとプロンプトを入力して、リアルタイムでテーマ生成を試すことができます。
+          下のフォームでAPIキーとプロンプトを入力して、リアルタイムでテーマ生成を試すことができます。プロバイダーに「Gemini
+          Nano」を選んだ場合はAPIキーが不要で、生成はすべてブラウザ内で完結します。
         </Paragraph>
         <ThemeGenerator />
       </section>
@@ -109,10 +110,109 @@ export default async function RootLayout({
         />
       </section>
 
+      <section className={styles.browserSection}>
+        <Heading level="h2">ブラウザ内での使用（Gemini Nano）</Heading>
+        <Paragraph>
+          <code className={styles.inlineCode}>
+            provider: &quot;browser&quot;
+          </code>
+          を指定すると、ChromeやEdgeが搭載するGemini
+          Nanoでテーマを生成します。APIキーもサーバーへの通信も不要で、生成はすべて端末上で完結します。この指定のときだけはServer
+          ComponentではなくClient
+          Componentから呼び出してください。ブラウザ内でしか動作しないためです。
+        </Paragraph>
+        <Paragraph>
+          利用できるかどうかは
+          <code className={styles.inlineCode}>getBrowserAIAvailability()</code>
+          で判定できます。戻り値は
+          <code className={styles.inlineCode}>
+            &quot;unavailable&quot;
+          </code> /{" "}
+          <code className={styles.inlineCode}>&quot;downloadable&quot;</code> /{" "}
+          <code className={styles.inlineCode}>&quot;downloading&quot;</code> /{" "}
+          <code className={styles.inlineCode}>&quot;available&quot;</code>
+          で、未対応環境ではクラウドのプロバイダーにフォールバックしてください。初回利用時はモデルのダウンロードに数GBの通信が発生するため、
+          <code className={styles.inlineCode}>onDownloadProgress</code>
+          で進捗を表示することを推奨します。
+        </Paragraph>
+        <CodeBlock
+          code={`"use client";
+
+import { getBrowserAIAvailability, ThemeClient } from "@ginga-ui/utils";
+import { useState } from "react";
+
+export function BrowserThemeButton() {
+  const [css, setCss] = useState("");
+
+  const generate = async () => {
+    const availability = await getBrowserAIAvailability();
+
+    if (availability === "unavailable") {
+      return;
+    }
+
+    const themeClient = new ThemeClient({ provider: "browser" });
+
+    const { CSSCode } = await themeClient.generateTheme("深海の静けさ", {
+      onDownloadProgress: (progress) => {
+        console.log(\`ダウンロード中: \${Math.round(progress * 100)}%\`);
+      },
+    });
+
+    setCss(CSSCode);
+  };
+
+  return (
+    <>
+      <button onClick={generate}>テーマを生成</button>
+      <style>{css}</style>
+    </>
+  );
+}`}
+          highlightedCode={await highlightCode(
+            `"use client";
+
+import { getBrowserAIAvailability, ThemeClient } from "@ginga-ui/utils";
+import { useState } from "react";
+
+export function BrowserThemeButton() {
+  const [css, setCss] = useState("");
+
+  const generate = async () => {
+    const availability = await getBrowserAIAvailability();
+
+    if (availability === "unavailable") {
+      return;
+    }
+
+    const themeClient = new ThemeClient({ provider: "browser" });
+
+    const { CSSCode } = await themeClient.generateTheme("深海の静けさ", {
+      onDownloadProgress: (progress) => {
+        console.log(\`ダウンロード中: \${Math.round(progress * 100)}%\`);
+      },
+    });
+
+    setCss(CSSCode);
+  };
+
+  return (
+    <>
+      <button onClick={generate}>テーマを生成</button>
+      <style>{css}</style>
+    </>
+  );
+}`,
+            "tsx"
+          )}
+        />
+      </section>
+
       <section className={styles.providersSection}>
         <Heading level="h2">サポートされているLLMプロバイダー</Heading>
         <Paragraph>
-          ThemeClientは3つの主要なLLMプロバイダーをサポートしています。
+          ThemeClientは3つのクラウドLLMプロバイダーと、ブラウザ内蔵のGemini
+          Nanoをサポートしています。
           <code className={styles.inlineCode}>provider</code>
           で使用するプロバイダーを指定し、
           <code className={styles.inlineCode}>model</code>
@@ -179,6 +279,21 @@ export default async function RootLayout({
             <li>
               <code className={styles.inlineCode}>claude-opus-5</code> —
               最高品質
+            </li>
+          </ul>
+
+          <Heading level="h3" className={styles.nextSubsection}>
+            Gemini Nano —{" "}
+            <code className={styles.inlineCode}>
+              provider: &quot;browser&quot;
+            </code>
+          </Heading>
+          <ul className={styles.providersList}>
+            <li>
+              <code className={styles.inlineCode}>gemini-nano</code> —
+              APIキー不要、ブラウザ内で実行。
+              <code className={styles.inlineCode}>model</code>
+              の指定は不要です
             </li>
           </ul>
         </div>

--- a/app/ginga-ui.com/src/components/theme-generator.tsx
+++ b/app/ginga-ui.com/src/components/theme-generator.tsx
@@ -1,17 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Input, Select } from "@ginga-ui/core";
-import type { ThemeProvider } from "@ginga-ui/utils";
+import type { BrowserAIAvailability, ThemeProvider } from "@ginga-ui/utils";
 import { ListBoxItem } from "react-aria-components";
 import { CodeBlock } from "./code-block";
 import styles from "./theme-generator.module.css";
 
-const MODELS: Record<ThemeProvider, string[]> = {
+type ServerThemeProvider = Exclude<ThemeProvider, "browser">;
+
+const MODELS: Record<ServerThemeProvider, string[]> = {
   openai: ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"],
   google: ["gemini-3.7-flash", "gemini-3.5-flash-lite", "gemini-2.5-pro"],
   anthropic: ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-5"],
 };
+
+const AVAILABILITY_MESSAGES: Record<BrowserAIAvailability, string> = {
+  unavailable:
+    "このブラウザではGemini Nanoを利用できません。デスクトップ版のChromeまたはEdgeでお試しください。",
+  downloadable:
+    "初回生成時にGemini Nanoのモデルがダウンロードされます。数GBの通信が発生し、完了までに時間がかかります。",
+  downloading: "Gemini Nanoのモデルをダウンロード中です。",
+  available: "Gemini Nanoが利用可能です。APIキーもサーバー通信も不要です。",
+};
+
+type GenerateResult = { type: "success" | "error"; CSSCode: string };
 
 export function ThemeGenerator() {
   const [provider, setProvider] = useState<ThemeProvider>("openai");
@@ -21,10 +34,71 @@ export function ThemeGenerator() {
   const [cssCode, setCssCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [availability, setAvailability] =
+    useState<BrowserAIAvailability | null>(null);
+  const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
+
+  const isBrowserProvider = provider === "browser";
+
+  useEffect(() => {
+    if (!isBrowserProvider || availability !== null) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      const { getBrowserAIAvailability } = await import("@ginga-ui/utils");
+      const result = await getBrowserAIAvailability();
+      if (!cancelled) {
+        setAvailability(result);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isBrowserProvider, availability]);
+
+  const generateInBrowser = async (): Promise<GenerateResult> => {
+    const { ThemeClient } = await import("@ginga-ui/utils");
+    const client = new ThemeClient({ provider: "browser" });
+
+    return client.generateTheme(prompt, {
+      onDownloadProgress: (progress) =>
+        setDownloadProgress(progress < 1 ? Math.round(progress * 100) : null),
+    });
+  };
+
+  const generateOnServer = async (): Promise<GenerateResult> => {
+    const response = await fetch("/api/generate-theme", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        prompt,
+        apiKey,
+        provider,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || "テーマ生成に失敗しました");
+    }
+
+    return response.json();
+  };
 
   const handleGenerate = async () => {
-    if (!apiKey || !prompt) {
-      setError("APIキーとプロンプトを入力してください");
+    if (!prompt || (!isBrowserProvider && !apiKey)) {
+      setError(
+        isBrowserProvider
+          ? "プロンプトを入力してください"
+          : "APIキーとプロンプトを入力してください"
+      );
       return;
     }
 
@@ -32,26 +106,9 @@ export function ThemeGenerator() {
     setError("");
 
     try {
-      // サーバーサイドRoute Handlerを使用
-      const response = await fetch("/api/generate-theme", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model,
-          prompt,
-          apiKey,
-          provider,
-        }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "テーマ生成に失敗しました");
-      }
-
-      const result = await response.json();
+      const result = isBrowserProvider
+        ? await generateInBrowser()
+        : await generateOnServer();
 
       if (result.type === "success") {
         setCssCode(result.CSSCode);
@@ -68,22 +125,44 @@ export function ThemeGenerator() {
       setError(e instanceof Error ? e.message : "テーマ生成に失敗しました");
     } finally {
       setLoading(false);
+      setDownloadProgress(null);
     }
   };
 
   const handleProviderChange = (newProvider: ThemeProvider) => {
     setProvider(newProvider);
-    setModel(MODELS[newProvider][0]);
+    if (newProvider !== "browser") {
+      setModel(MODELS[newProvider][0]);
+    }
+  };
+
+  const buttonLabel = () => {
+    if (!loading) {
+      return "テーマを生成";
+    }
+    return downloadProgress === null
+      ? "生成中..."
+      : `モデルをダウンロード中... ${downloadProgress}%`;
   };
 
   return (
     <div className={styles.container}>
       <div className={styles.warningBox}>
         <p className={styles.warningText}>
-          ⚠️
-          <strong>セキュリティ上の注意:</strong>
-          このデモで入力したAPIキーはサーバーサイドのRoute
-          Handlerへ送信され、テーマ生成にのみ使用されます。保存はされません。本番環境ではAPIキーをクライアントから受け取らず、サーバーサイドの環境変数から読み込んでください。
+          {isBrowserProvider ? (
+            <>
+              💡<strong>ブラウザ内で完結します:</strong>
+              Gemini
+              Nanoを使うため、APIキーの入力もサーバーへの通信も不要です。生成はすべて端末上で実行されます。
+            </>
+          ) : (
+            <>
+              ⚠️
+              <strong>セキュリティ上の注意:</strong>
+              このデモで入力したAPIキーはサーバーサイドのRoute
+              Handlerへ送信され、テーマ生成にのみ使用されます。保存はされません。本番環境ではAPIキーをクライアントから受け取らず、サーバーサイドの環境変数から読み込んでください。
+            </>
+          )}
         </p>
       </div>
 
@@ -95,32 +174,45 @@ export function ThemeGenerator() {
         <ListBoxItem id="openai">OpenAI</ListBoxItem>
         <ListBoxItem id="google">Google Gemini</ListBoxItem>
         <ListBoxItem id="anthropic">Anthropic Claude</ListBoxItem>
+        <ListBoxItem id="browser">Gemini Nano</ListBoxItem>
       </Select>
 
-      <Select
-        label="モデル"
-        selectedKey={model}
-        onSelectionChange={(key) => setModel(key as string)}
-      >
-        {MODELS[provider].map((m) => (
-          <ListBoxItem key={m} id={m}>
-            {m}
-          </ListBoxItem>
-        ))}
-      </Select>
+      {isBrowserProvider ? (
+        availability && (
+          <div className={styles.warningBox}>
+            <p className={styles.warningText}>
+              {AVAILABILITY_MESSAGES[availability]}
+            </p>
+          </div>
+        )
+      ) : (
+        <>
+          <Select
+            label="モデル"
+            selectedKey={model}
+            onSelectionChange={(key) => setModel(key as string)}
+          >
+            {MODELS[provider].map((m) => (
+              <ListBoxItem key={m} id={m}>
+                {m}
+              </ListBoxItem>
+            ))}
+          </Select>
 
-      <div>
-        <label htmlFor="api-key-input" className={styles.fieldLabel}>
-          APIキー
-        </label>
-        <Input
-          id="api-key-input"
-          type="password"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          placeholder="sk-..."
-        />
-      </div>
+          <div>
+            <label htmlFor="api-key-input" className={styles.fieldLabel}>
+              APIキー
+            </label>
+            <Input
+              id="api-key-input"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="sk-..."
+            />
+          </div>
+        </>
+      )}
 
       <div>
         <label htmlFor="theme-prompt-input" className={styles.fieldLabel}>
@@ -137,9 +229,13 @@ export function ThemeGenerator() {
       <Button
         variant="filled"
         onPress={handleGenerate}
-        disabled={!apiKey || !prompt || loading}
+        disabled={
+          !prompt ||
+          loading ||
+          (isBrowserProvider ? availability === "unavailable" : !apiKey)
+        }
       >
-        {loading ? "生成中..." : "テーマを生成"}
+        {buttonLabel()}
       </Button>
 
       {error && (

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,6 +50,7 @@
     "@ai-sdk/anthropic": "4.0.37",
     "@ai-sdk/google": "4.0.40",
     "@ai-sdk/openai": "4.0.37",
+    "@browser-ai/core": "3.0.0",
     "ai": "7.0.59",
     "chroma-js": "3.2.0",
     "zod": "4.4.3"

--- a/packages/utils/src/ai/browser.ts
+++ b/packages/utils/src/ai/browser.ts
@@ -1,0 +1,20 @@
+export type BrowserAIAvailability =
+  | "unavailable"
+  | "downloadable"
+  | "downloading"
+  | "available";
+
+export async function getBrowserAIAvailability(): Promise<BrowserAIAvailability> {
+  if (typeof window === "undefined") {
+    return "unavailable";
+  }
+
+  const { doesBrowserSupportBrowserAI, browserAI } =
+    await import("@browser-ai/core");
+
+  if (!doesBrowserSupportBrowserAI()) {
+    return "unavailable";
+  }
+
+  return browserAI("text").availability();
+}

--- a/packages/utils/src/ai/index.ts
+++ b/packages/utils/src/ai/index.ts
@@ -9,27 +9,29 @@ import { generateIntermediateColors } from "../lib/color";
 import { SYSTEM_PROMPT } from "./const";
 import { themeVariablesSchema, type ThemeVariables } from "./schema";
 
-export const PROVIDERS = {
-  openai,
-  google,
-  anthropic,
-} as const;
-
-export type ThemeProvider = keyof typeof PROVIDERS;
+export * from "./browser";
 
 export const DEFAULT_MODELS = {
   openai: "gpt-5.6-luna",
   google: "gemini-3.7-flash",
   anthropic: "claude-haiku-4-5",
-} as const satisfies Record<ThemeProvider, string>;
+  browser: "text",
+} as const;
+
+export type ThemeProvider = keyof typeof DEFAULT_MODELS;
+
+export const PROVIDERS = Object.keys(DEFAULT_MODELS) as ThemeProvider[];
 
 export type ThemeClientConstructorProps = {
   provider: ThemeProvider;
   model?: string;
 };
 
+export type DownloadProgressCallback = (progress: number) => void;
+
 export type GenerateThemeOptions = {
   maxRetries?: number;
+  onDownloadProgress?: DownloadProgressCallback;
 };
 
 export class ThemeClient {
@@ -38,14 +40,16 @@ export class ThemeClient {
   private maxRetries: number = 3;
 
   constructor({ provider, model }: ThemeClientConstructorProps) {
-    if (!(provider in PROVIDERS)) {
+    if (!PROVIDERS.includes(provider)) {
       throw new Error(`Unsupported provider: ${provider}`);
     }
     this.provider = provider;
     this.model = model ?? DEFAULT_MODELS[provider];
   }
 
-  private getLanguageModel() {
+  private async getLanguageModel(
+    onDownloadProgress?: DownloadProgressCallback
+  ) {
     switch (this.provider) {
       case "openai":
         return openai(this.model);
@@ -53,6 +57,14 @@ export class ThemeClient {
         return google(this.model);
       case "anthropic":
         return anthropic(this.model);
+      case "browser": {
+        const { browserAI } = await import("@browser-ai/core");
+        const model = browserAI("text");
+        if (onDownloadProgress) {
+          await model.createSessionWithProgress(onDownloadProgress);
+        }
+        return model;
+      }
     }
   }
 
@@ -61,10 +73,19 @@ export class ThemeClient {
       this.maxRetries = options.maxRetries;
     }
 
+    let model;
+    try {
+      model = await this.getLanguageModel(options?.onDownloadProgress);
+    } catch (e) {
+      const errorMessage =
+        e instanceof Error ? e.message : "Failed to prepare language model";
+      return { type: "error", CSSCode: errorMessage } as const;
+    }
+
     for (let i = 0; i < this.maxRetries; i++) {
       try {
         const { object } = await generateObject({
-          model: this.getLanguageModel(),
+          model,
           schema: themeVariablesSchema,
           system: SYSTEM_PROMPT,
           prompt,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 4.0.37
         version: 4.0.37(zod@4.4.3)
+      '@browser-ai/core':
+        specifier: 3.0.0
+        version: 3.0.0(ai@7.0.59(zod@4.4.3))
       ai:
         specifier: 7.0.59
         version: 7.0.59(zod@4.4.3)
@@ -264,6 +267,11 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@browser-ai/core@3.0.0':
+    resolution: {integrity: sha512-Ncfa6gW6BgDzLrNaCARqZ6vJAVPf4skiAzmJWi2l9Nfzjs8bQy2dt8X4cJROHAVJvf3aM4aUsW3aKtWTANRF5w==}
+    peerDependencies:
+      ai: ^7.0.0
 
   '@cacheable/memory@2.2.0':
     resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
@@ -783,6 +791,9 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mediapipe/tasks-text@0.10.35':
+    resolution: {integrity: sha512-BlRWXZAHakqtAos8hNgSU0jy4mh60R9ewzwckS3q2nV7Q/7L65otCtoDrgslRBhlfbElfcHbHQXKRahlMRCf4Q==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -4365,6 +4376,11 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@browser-ai/core@3.0.0(ai@7.0.59(zod@4.4.3))':
+    dependencies:
+      '@mediapipe/tasks-text': 0.10.35
+      ai: 7.0.59(zod@4.4.3)
+
   '@cacheable/memory@2.2.0':
     dependencies:
       '@cacheable/utils': 2.5.0
@@ -4882,6 +4898,8 @@ snapshots:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.18
       react: 19.2.8
+
+  '@mediapipe/tasks-text@0.10.35': {}
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:


### PR DESCRIPTION
## 概要

`ThemeClient` に Gemini Nano を使う `provider: "browser"` を追加しました。API キーもサーバーへの通信も不要で、テーマ生成がブラウザ内で完結します。

Closes #110

## 変更内容

### `@ginga-ui/utils`

- `provider: "browser"` を追加。AI SDK プロバイダーとして `@browser-ai/core` を利用し、サーバー実行時に読み込まれないよう動的 import している
- プロバイダー定義を `DEFAULT_MODELS` に一本化し、`PROVIDERS` を `ThemeProvider[]` に変更
- Gemini Nano が使えるかを判定する `getBrowserAIAvailability()` と `BrowserAIAvailability` 型を追加。型は自前定義のため、利用者側で `@types/dom-chromium-ai` を入れなくても壊れない
- `GenerateThemeOptions` に `onDownloadProgress` を追加し、初回のモデルダウンロード進捗を受け取れるようにした

### ドキュメントサイト

- ライブデモのプロバイダーに「Gemini Nano」を追加。選択時は API キー欄とモデル選択を隠し、availability に応じた案内を表示して、Route Handler を経由せずブラウザ内で生成する
- `@ginga-ui/utils` を動的 import し、クライアントバンドルに AI SDK 一式が常時載らないようにした
- テーマ生成ページに「ブラウザ内での使用（Gemini Nano）」の節を追加

## 動作確認

- `npx tsc --noEmit && pnpm lint && pnpm format && pnpm stylelint` および `pnpm build` がすべて通過
- ビルド成果物で `@browser-ai/core` が動的 import のまま残っていることを確認
- Chrome 151 で実際にテーマ生成が成功し、サイト全体に適用されることを確認。dev サーバーのログに `/api/generate-theme` へのリクエストが 0 件であることも確認済み
- OpenAI 選択時の UI と、サーバーサイド（`layout.tsx`）のテーマ生成が従来どおり動くことを確認

## 補足

- `@browser-ai/core` は最新の 3.0.2 ではなく **3.0.0** をピンしています。pnpm の supply-chain policy（`minimumReleaseAge`）が公開直後の 3.0.2 を弾いたためです。API 面は同一で、期間経過後に上げられます。
- `.claude/settings.json` を追加しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
